### PR TITLE
Use standard engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
     "ws": "^8.2.3",
     "yargs": "^17.2.1"
   },
-  "devEngines": {
+  "engines": {
     "node": ">=20.x",
     "npm": ">=9.x"
   },


### PR DESCRIPTION
## Summary
- rename deprecated `devEngines` field to standard `engines`

## Testing
- `npm test` (fails: `jest: not found`)


------
https://chatgpt.com/codex/tasks/task_e_689d3a3806fc832f8d0d33b1eb880480